### PR TITLE
Send nil when value is not present and have on custom sanitizers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.1.1
+
+Fix some bugs:
+
+* Predefined sanitizers are converting `nil` values into a blank string (`''`)
+* Fix `Stack too deep level` when duplicated `sanitize_attributes`, like `sanitize_attributes :title, with: [:strip_tags, :strip_emojis]`
+
 # 0.1.0
 
 Initial version.

--- a/lib/attributes_sanitizer/predefined.rb
+++ b/lib/attributes_sanitizer/predefined.rb
@@ -1,20 +1,19 @@
 AttributesSanitizer.define_sanitizer :downcase do |value|
-  value.to_s.downcase
+  value.to_s.downcase if value
 end
 
 AttributesSanitizer.define_sanitizer :upcase do |value|
-  value.to_s.upcase
+  value.to_s.upcase if value
 end
 
 AttributesSanitizer.define_sanitizer :strip_tags do |value|
-  ActionController::Base.helpers.sanitize(value.to_s, tags: []).strip
+  ActionController::Base.helpers.sanitize(value.to_s, tags: []).strip if value
 end
 
 AttributesSanitizer.define_sanitizer :strip_emojis do |value|
-  value.to_s.gsub(AttributesSanitizer::EMOJI_REGEX, '')
+  value.to_s.gsub(AttributesSanitizer::EMOJI_REGEX, '') if value
 end
 
 AttributesSanitizer.define_sanitizer :strip_spaces do |value|
-  value.to_s.strip
+  value.to_s.strip if value
 end
-


### PR DESCRIPTION
Sends nil to the model when the value of param is nil.