### PR TITLE
Convert attributes to string when sent to sanitizer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ env:
 language: ruby
 rvm:
   - 2.5.0
-before_install: gem install bundler -v 1.16.1
+  - 2.5.1
+before_install: gem install bundler
 notifications:
   - false
 before_script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 0.1.1
+
+First stable version.
+
+- Fix bug with duplicated sanitizer name on fields declaration
+- Add possibility to stack the validations in order of decalration. Example: `sanitize_attributes :title, with: [:stringify, :strip_tags, :strip_spaces]` -> `strinfigy` will be the first executed, and `strip_spaces` the last.
+- Added `:stringify` as default sanitizer, to perform a `.to_s` on attribute
+
 # 0.1.0
 
 Initial version.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    attributes_sanitizer (0.1.0)
+    attributes_sanitizer (0.1.1)
       rails (~> 5)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ end
 ```
 
 It comes with pre-defined sanitizers:
+- `:stringify` which perform a `to_s` into the value, to be sanitized as a string. Can be used before other sanitizer, that depends to the value be a string
 - `:downcase` which downcases a given attribute string
 - `:upcase` which upcases a given attribute string
 - `:strip_tags` which removes any tags from the given string based on Rails sanitize helper.

--- a/lib/attributes_sanitizer/predefined.rb
+++ b/lib/attributes_sanitizer/predefined.rb
@@ -3,6 +3,10 @@ module AttributesSanitizer
     extend ActiveSupport::Concern
 
     included do
+      AttributesSanitizer.define_sanitizer :stringify do |value|
+        value.to_s
+      end
+
       AttributesSanitizer.define_sanitizer :downcase do |value|
         value.downcase
       end
@@ -25,4 +29,3 @@ module AttributesSanitizer
     end
   end
 end
-

--- a/lib/attributes_sanitizer/version.rb
+++ b/lib/attributes_sanitizer/version.rb
@@ -1,3 +1,3 @@
 module AttributesSanitizer
-  VERSION = '0.1.0'
+  VERSION = '0.1.1'
 end

--- a/test/attributes_sanitizer_test.rb
+++ b/test/attributes_sanitizer_test.rb
@@ -126,24 +126,35 @@ class AttributesSanitizer::Test < AttributesSanitizer::TestCase
     product = Product.new(title: 'Title <b>123</b> 😀  ')
     assert_sanitized_attribute product, :title, 'title <b>123</b> 😀  '
   end
+
   test "pre-defined sanitizer upcase" do
     Product.sanitize_attribute :title, with: :upcase
     product = Product.new(title: 'Title <b>123</b> 😀  ')
     assert_sanitized_attribute product, :title, 'TITLE <B>123</B> 😀  '
   end
+
   test "pre-defined sanitizer strip_tags" do
     Product.sanitize_attribute :title, with: :strip_tags
     product = Product.new(title: 'Title <b>123</b> 😀  ')
     assert_sanitized_attribute product, :title, 'Title 123 😀  '
   end
+
   test "pre-defined sanitizer strip_emojis" do
     Product.sanitize_attribute :title, with: :strip_emojis
     product = Product.new(title: 'Title <b>123</b> 😀  ')
     assert_sanitized_attribute product, :title, 'Title <b>123</b>   '
   end
+
   test "pre-defined sanitizer strip_spaces" do
     Product.sanitize_attribute :title, with: :strip_spaces
     product = Product.new(title: 'Title <b>123</b> 😀  ')
     assert_sanitized_attribute product, :title, 'Title <b>123</b> 😀'
+  end
+
+  test "pre-defined strip_tags with number could be converted to string" do
+    Product.sanitize_attribute :title, with: [:stringify, :strip_tags]
+    product = Product.new(title: 123)
+
+    assert_sanitized_attribute product, :title, '123'
   end
 end


### PR DESCRIPTION
## Problem:

We have problems when the value is not a string on `strip_tags` predefined converter.

```
[2] pry(main)> ActionController::Base.helpers.sanitize(1, tags: [])
NoMethodError: undefined method `empty?' for 1:Integer
from /usr/local/bundle/gems/rails-html-sanitizer-1.0.4/lib/rails/html/sanitizer.rb:118:in `sanitize'
[3] pry(main)> ActionController::Base.helpers.sanitize(1.to_s, tags: [])
=> "1"
[4] pry(main)> 
```

## Solution:

Created a predefined `stringify` sanitizer, to add before the `strip_tags` method.