### PR TITLE
Adding support for Rails 6 and updating test dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ test/dummy/storage/
 test/dummy/tmp/
 coverage
 *.gem
+.ruby-version

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     attributes_sanitizer (0.1.5)
-      rails (~> 5)
+      rails (> 5, < 7)
 
 GEM
   remote: https://rubygems.org/
@@ -50,6 +50,8 @@ GEM
       tzinfo (~> 1.1)
     ansi (1.5.0)
     arel (9.0.0)
+    bootsnap (1.7.4)
+      msgpack (~> 1.0)
     builder (3.2.4)
     concurrent-ruby (1.1.8)
     crass (1.0.6)
@@ -75,6 +77,7 @@ GEM
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)
     minitest (5.14.4)
+    msgpack (1.4.2)
     nio4r (2.5.5)
     nokogiri (1.11.1)
       mini_portile2 (~> 2.5.0)
@@ -138,9 +141,10 @@ PLATFORMS
 
 DEPENDENCIES
   attributes_sanitizer!
+  bootsnap
   simplecov
   simplecov-console
   sqlite3
 
 BUNDLED WITH
-   1.16.6
+   2.2.16

--- a/attributes_sanitizer.gemspec
+++ b/attributes_sanitizer.gemspec
@@ -22,7 +22,8 @@ Gem::Specification.new do |s|
     "source_code_uri"   => "https://github.com/andersondias/attributes_sanitizer"
   }
 
-  s.add_dependency "rails", "~> 5"
+  s.add_dependency "rails", "> 5", "< 7"
 
+  s.add_development_dependency "bootsnap"
   s.add_development_dependency "sqlite3"
 end

--- a/test/dummy/config/application.rb
+++ b/test/dummy/config/application.rb
@@ -2,8 +2,9 @@ require_relative 'boot'
 
 require 'rails/all'
 
+# Require the gems listed in Gemfile, including any gems
+# you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
-require "attributes_sanitizer"
 
 module Dummy
   class Application < Rails::Application
@@ -16,4 +17,3 @@ module Dummy
     # the framework and any gems in your application.
   end
 end
-

--- a/test/dummy/config/boot.rb
+++ b/test/dummy/config/boot.rb
@@ -1,5 +1,4 @@
-# Set up gems listed in the Gemfile.
-ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../../Gemfile', __dir__)
+ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 
-require 'bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE'])
-$LOAD_PATH.unshift File.expand_path('../../../lib', __dir__)
+require 'bundler/setup' # Set up gems listed in the Gemfile.
+require 'bootsnap/setup' # Speed up boot time by caching expensive operations.

--- a/test/dummy/config/environments/development.rb
+++ b/test/dummy/config/environments/development.rb
@@ -57,5 +57,5 @@ Rails.application.configure do
 
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
-  # config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+  config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 end

--- a/test/dummy/config/initializers/new_framework_defaults_5_2.rb
+++ b/test/dummy/config/initializers/new_framework_defaults_5_2.rb
@@ -1,0 +1,38 @@
+# Be sure to restart your server when you modify this file.
+#
+# This file contains migration options to ease your Rails 5.2 upgrade.
+#
+# Once upgraded flip defaults one by one to migrate to the new default.
+#
+# Read the Guide for Upgrading Ruby on Rails for more info on each option.
+
+# Make Active Record use stable #cache_key alongside new #cache_version method.
+# This is needed for recyclable cache keys.
+# Rails.application.config.active_record.cache_versioning = true
+
+# Use AES-256-GCM authenticated encryption for encrypted cookies.
+# Also, embed cookie expiry in signed or encrypted cookies for increased security.
+#
+# This option is not backwards compatible with earlier Rails versions.
+# It's best enabled when your entire app is migrated and stable on 5.2.
+#
+# Existing cookies will be converted on read then written with the new scheme.
+# Rails.application.config.action_dispatch.use_authenticated_cookie_encryption = true
+
+# Use AES-256-GCM authenticated encryption as default cipher for encrypting messages
+# instead of AES-256-CBC, when use_authenticated_message_encryption is set to true.
+# Rails.application.config.active_support.use_authenticated_message_encryption = true
+
+# Add default protection from forgery to ActionController::Base instead of in
+# ApplicationController.
+# Rails.application.config.action_controller.default_protect_from_forgery = true
+
+# Store boolean values are in sqlite3 databases as 1 and 0 instead of 't' and
+# 'f' after migrating old data.
+# Rails.application.config.active_record.sqlite3.represent_boolean_as_integer = true
+
+# Use SHA-1 instead of MD5 to generate non-sensitive digests, such as the ETag header.
+# Rails.application.config.active_support.use_sha1_digests = true
+
+# Make `form_with` generate id attributes for any generated HTML tags.
+# Rails.application.config.action_view.form_with_generates_ids = true


### PR DESCRIPTION
The lastest supported and tested version for attributes_sanitizer was Rails 5. In this commit I'm adding support to Rails 6 excluding 7+ as it is about to be released.

I've also taken the opportunity to improve test dependencies.
Rails 5.2 relies on bootsnap to speed up it's execution time.

And I've  added .ruby-version file to .gitignore.